### PR TITLE
Typo fix for BR.

### DIFF
--- a/Translations/pt-BR.lproj/main.strings
+++ b/Translations/pt-BR.lproj/main.strings
@@ -102,4 +102,4 @@
 "v5b-pg-pYC.title" = "Copiar";
 
 /* Class = "NSMenuItem"; title = "Select All"; ObjectID = "wbR-ho-uar"; */
-"wbR-ho-uar.title" = "Seleccionar Tudo";
+"wbR-ho-uar.title" = "Selecionar Tudo";


### PR DESCRIPTION
“Seleccionar Tudo” should actually be “Selecionar Tudo”. Sorry about that.