### PR TITLE
Credits: Fix typo in German Translation

### DIFF
--- a/Translations/de.lproj/Credits.html
+++ b/Translations/de.lproj/Credits.html
@@ -80,7 +80,7 @@
         
         
 	<!-- START LICENSE -->
-	<p class="license">Der Quellcode von Keka 1.0 wird  aufgrund einiger rechtlicher Fragen nicht veröffentlicht. Rechtsbeistand wird benötigt, wenn Sie das Projekt in dieser Hinsicht unterstützen können, nehmen Sie bitte Kontakt auf über info@keka.io oder die Projekt-Seite auf  der offiziellen Keka Webseite. Jede Hilfe ist willkommen..Der Quellcode von Keka 1.0 wird  aufgrund einiger rechtlicher Fragen nicht veröffentlicht. Rechtsbeistand wird benötigt, wenn Sie das Projekt in dieser Hinsicht unterstützen können, nehmen Sie bitte Kontakt auf über info@keka.io oder die Projekt-Seite auf  der offiziellen Keka Webseite. Jede Hilfe ist willkommen.</p>
+	<p class="license">Der Quellcode von Keka 1.0 wird  aufgrund einiger rechtlicher Fragen nicht veröffentlicht. Rechtsbeistand wird benötigt, wenn Sie das Projekt in dieser Hinsicht unterstützen können, nehmen Sie bitte Kontakt auf über info@keka.io oder die Projekt-Seite auf  der offiziellen Keka Webseite. Jede Hilfe ist willkommen.</p>
 	<!-- END LICENSE -->
     
     


### PR DESCRIPTION
The license part was in there twice (both identical), removed one.