### PR TITLE
Translate 'Rename the recognized extension from the subfolder' to German

### DIFF
--- a/Translations/Common/Translators.html
+++ b/Translations/Common/Translators.html
@@ -64,6 +64,7 @@
 	<span>
 		<h2>Deutsch</h2>
 		<span>Alexander Wasenauer</span>
+		<span>Clemens Bartz <a href="https://github.com/clemensbartz">@clemensbartz</a></span>
 		<span>S.Brandt</span>
 		<span>@iOSLaura <a href="https://github.com/iOSLaura">@iOSLaura</a></span>
 		<span>@speck-drum <a href="https://github.com/speck-drum">@speck-drum</a></span>

--- a/Translations/de.lproj/preferences.strings
+++ b/Translations/de.lproj/preferences.strings
@@ -114,7 +114,7 @@
 "453.title" = "Keinen";
 
 /* Class = "NSButtonCell"; title = "Rename the recognized extension from the subfolder"; ObjectID = "1TK-Zy-623"; */
-"1TK-Zy-623.title" = "Rename the recognized extension from the subfolder";
+"1TK-Zy-623.title" = "Suffix des Unterordners anpassen";
 
 /* Class = "NSButtonCell"; title = "Show icon in primary item"; ObjectID = "47Y-rt-2fG"; */
 "47Y-rt-2fG.title" = "Icon im Kontextmenü anzeigen";


### PR DESCRIPTION
Translate recognized extension from intermediate folder renaming in preferences.strings for German translation (issue #883).