### PR TITLE
Improve grammar of Dutch translation of “Verify compression integrity”

### DIFF
--- a/Translations/nl.lproj/advanced.strings
+++ b/Translations/nl.lproj/advanced.strings
@@ -87,4 +87,4 @@
 "dDw-7W-5ff.title" = "Indeling:";
 
 /* Class = "NSButtonCell"; title = "Verify compression integrity"; ObjectID = "gqN-A9-jPb"; */
-"gqN-A9-jPb.title" = "Verifieer compressie integriteit";
+"gqN-A9-jPb.title" = "Compressie-integriteit verifiëren";


### PR DESCRIPTION
I personally think the current translation sounds slightly unnatural and this sounds slightly better.

Alternatively maybe something like “Controleer de integriteit van de compressie”.