### PR TITLE
Update Polish translation

### DIFF
--- a/Translations-macOS/pl.lproj/advanced.strings
+++ b/Translations-macOS/pl.lproj/advanced.strings
@@ -75,7 +75,7 @@
 "2426.title" = "Powtórz:";
 
 /* Class = "NSButtonCell"; title = "Self-extracting archive for Windows"; ObjectID = "Itb-5A-JW7"; */
-"Itb-5A-JW7.title" = "Self-extracting archive for Windows";
+"Itb-5A-JW7.title" = "Samowyodrębniające się archiwum dla Windowsa";
 
 /* Class = "NSButtonCell"; title = "Encrypt filenames"; ObjectID = "L2I-Q8-zqc"; */
 "L2I-Q8-zqc.title" = "Szyfrowanie nazw plików";

--- a/Translations-macOS/pl.lproj/preferences.strings
+++ b/Translations-macOS/pl.lproj/preferences.strings
@@ -114,7 +114,7 @@
 "453.title" = "Brak";
 
 /* Class = "NSButtonCell"; title = "Show compress contents of folder items"; ObjectID = "0Am-9a-jtM"; */
-"0Am-9a-jtM.title" = "Pokaż zarchiwizowaną zawartość plików w folderach";
+"0Am-9a-jtM.title" = "Pokaż opcje \"Archiwizuj zawartość folderu\"";
 
 /* Class = "NSButtonCell"; title = "Rename the recognized extension from the subfolder"; ObjectID = "1TK-Zy-623"; */
 "1TK-Zy-623.title" = "Zmień nazwę rozpoznanego rozszerzenia z podfolderu";


### PR DESCRIPTION
Added a missing translation for "Self-extracting archive for Windows" and fixed a mistranslation of "Show compress contents of folder items". 

Side note: I believe that the string `"Show compress contents of folder items"` should be changed to `"Show \"compress contents of folder\" items"`, since it's not clear that it refers to showing the items in the context menu and not showing the contents of some folder (which by the way is how it was interpreted by whoever translated this into Polish). Maybe consider even making it `"Show \"Compress contents of folder\" options (in context menu)"`