### PR TITLE
[macOS] Missing strings from the toolbar (IT)

### DIFF
--- a/Translations-macOS/it.lproj/Localizable.strings
+++ b/Translations-macOS/it.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "Show password" = "Mostra la password";
 "Hide password" = "Nascondi password";
 "Settings" = "Impostazioni";
-"Format Selector" = "Format Selector";
+"Format Selector" = "Selettore formato";
 
 /* Keka preferences for macOS 12.0 and earlier */
 "Preferences…" = "Preferenze…";


### PR DESCRIPTION
Update Localizable.strings (IT)