### PR TITLE
fix: update french translations

### DIFF
--- a/Translations-Web/lang_fr.php
+++ b/Translations-Web/lang_fr.php
@@ -51,7 +51,7 @@ $content_beta_unavailable = 'Il n\'y a pas de version Beta disponible en ce mome
 $content_beta_up = "Récupérer la dernière version";
 
 // Legacy
-$content_platform_legacy = "For $version_replace";
+$content_platform_legacy = "Pour $version_replace";
 $content_legacy_title = "Anciennes versions de Keka";
 $content_legacy_text = 'Au fil des années, votre Mac va vieillir et ne pourra plus supporter<br />le dernier Keka, mais relax <i class="fa fa-coffee" aria-hidden="true"></i>, les anciennes versions seront ici.';
 

--- a/Translations-Web/lang_fr.php
+++ b/Translations-Web/lang_fr.php
@@ -9,13 +9,13 @@ $content_language_locale = "fr";
 //
 // Set $show_content_bottom_translator as true if you want to appear in the bottom of the page
 $show_content_bottom_translator = false;
-$content_bottom_translator = 'Traduit par Marc66';
+$content_bottom_translator = 'Traduit par Marc66 et <a href="https://methbkts.com/">Metin Bektas</a>.';
 //
 //
 
 // iOS
 $ios_title = "$keka pour iOS";
-$ios_content_title = "le compresseur pour iOS";
+$ios_content_title = "l'archiveur de fichiers pour iOS";
 
 // General
 $content_download = "Téléchargement";
@@ -23,7 +23,7 @@ $content_issues = "Problèmes";
 $content_help = "Aide";
 $content_forum = "Discussions";
 $content_changelog = "Liste des changements";
-$content_title = "Le compresseur de macOS";
+$content_title = "l'archiveur de fichiers pour macOS";
 
 // Download
 $content_platform = "Nécessite $version_replace ou plus récent";
@@ -38,22 +38,22 @@ $content_downloading_if_fails = "Si le téléchargement ne commence pas automati
 $content_downloading_if_fails_click_here = "cliquer ici";
 
 // Like
-$content_donation_button = "Donner";
+$content_donation_button = "Faire un don";
 $content_donation_title = 'Si vous aimez Keka, donnez lui de l\'<i class="fa fa-heart" aria-hidden="true"></i>, <br />récupérez-le depuis l\'App Store ou envoyez un pourboire!';
-$content_donation_mas = 'Si vous achetez Keka depuis l\'App Store vous supporterez son développement,<br />l\'application est la même que la version de ce site Web sauf qu\'elle est mise à jour à travers de l\'App Store.';
+$content_donation_mas = 'Si vous achetez Keka depuis l\'App Store vous supporterez son développement,<br />l\'application est la même que la version de ce site Web sauf qu\'elle est mise à jour au travers de l\'App Store.';
 $content_donation_paypal = 'Si vous n\'aimez pas le Mac App Store ou voulez juste essayer Keka<br />mais vous aimez le projet et voulez lui donner de l\'amour, vous pouvez envoyer un pourboire.';
 
 // Beta
 $content_platform_beta = "Beta";
 $content_beta_title = "Version Beta de Keka";
-$content_beta_text = 'Vous pouvez tester les dernières nouveuatés de Keka avant qu\'elles soient disponibles.<br />Si vous trouvez un bug ou voulez rapporter quelque chose, allez à ';
+$content_beta_text = 'Vous pouvez tester les dernières nouveautés de Keka avant qu\'elles soient disponibles.<br />Si vous trouvez un bug ou voulez rapporter quelque chose, allez à ';
 $content_beta_unavailable = 'Il n\'y a pas de version Beta disponible en ce moment.';
 $content_beta_up = "Récupérer la dernière version";
 
 // Legacy
-$content_platform_legacy =  "For $version_replace";
+$content_platform_legacy = "For $version_replace";
 $content_legacy_title = "Anciennes versions de Keka";
-$content_legacy_text = 'Au fil des années, votre Mac va vieillir et ne pourra plus supporter<br />le dernier Keka, mais relaxez <i class="fa fa-coffee" aria-hidden="true"></i>, les anciennes versions seront ici.';
+$content_legacy_text = 'Au fil des années, votre Mac va vieillir et ne pourra plus supporter<br />le dernier Keka, mais relax <i class="fa fa-coffee" aria-hidden="true"></i>, les anciennes versions seront ici.';
 
 // Info
 $content_info_title1 = "Si simple, si fort";
@@ -62,8 +62,8 @@ $content_info_title3 = "Toujours trop volumineux...";
 $content_info_text1 = 'Vous n\'avez même pas besoin d\'ouvrir Keka pour compresser un fichier, conservez-le dans le Dock et utilisez-le depuis là.<br />Il suffit de glisser et déplacer vos fichiers ou dossiers vers l\'icône du Dock ou la fenêtre Keka pour en créer une version réduite.';
 $content_info_text2 = "Partagez de façon sûre en ajoutant un mot de passe pour créer des fichiers hautement chiffrés.<br />Utilisation du chiffrement AES-256 pour vos fichiers 7z et<br />Le chiffrement ancien Zip 2.0 pour vos fichiers Zip.";
 $content_info_text3 = "Si les fichiers sont vraiment volumineux et ne tiennent pas dans vos emails ou votre serveur, il suffit de les diviser en morceaux.<br />Ne vous en faites pas, il seront décompressés pour reproduire votre fichier original :)";
-$content_info_compression = "Keka peut créer des fichiers dans ces formats:";
-$content_info_extraction = "Et extraire dans ces formats:";
+$content_info_compression = "Keka peut créer des fichiers dans ces formats :";
+$content_info_extraction = "Et extraire dans ces formats :";
 
 // Info v2 (iOS and future macOS)
 $content_info_v2_title1 = "Stockez plus";
@@ -73,7 +73,7 @@ $content_info_v2_title4 = "Le multi-tâche à son meilleur";
 $content_info_v2_title5 = "Toujours disponible";
 $content_info_v2_text1 = "Avec de nombreux formats de compression<br />pour choisir le meilleur";
 $content_info_v2_text2 = "Protégez vos fichiers partagés avec un mot de passe<br />et chiffrez-les avec AES-256";
-$content_info_v2_text3 = "Visualisez, Extrayez et Partagez<br />seulement ce que Vous voulez";
+$content_info_v2_text3 = "Visualisez, Extrayez et Partagez<br />juste ce qu'il Vous faut";
 $content_info_v2_text4 = "Extrayez, Compressez et Explorez<br />sans limite";
 $content_info_v2_text5 = "Extrayez, Compressez et Explorez<br />depuis n'importe où avec les actions de partage";
 
@@ -85,13 +85,13 @@ $content_defaultapp_text = 'Keka <a href="https://github.com/aonez/Keka/wiki/Def
 $content_termsofuse_title = 'Conditions d\'utilisation';
 $content_termsofuse_disclaimer = 'THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.';
 $content_termsofuse_inapp_title = 'Achats intégrés à l\'application';
-$content_termsofuse_inapp = 'La version App Store de Keka offre des achats intégrés à l\'application comme méthode de pourboire et pour aider au développement du projet, de façon similaire à <a href="https://www.keka.io/#lovekeka">PayPal/Parrainage sur le site Web</a>. Ces achats sont facultatifs et n\'offrent aucune fonctionnalités supplémentaires.';
+$content_termsofuse_inapp = 'La version App Store de Keka offre des achats intégrés à l\'application comme méthode de pourboire et pour aider au développement du projet, de façon similaire au <a href="https://www.keka.io/#lovekeka">PayPal/Parrainage sur le site Web</a>. Ces achats sont facultatifs et n\'offrent aucune fonctionnalité supplémentaire.';
 
 // Privacy Policy
-$content_privacypolicy_title = 'Politique de confidentialité';
+$content_privacypolicy_title = "Politique de confidentialité";
 $content_privacypolicy_content = 'Keka n\'envoit ni ne stocke aucune donnée sur votre ordinateur.';
 $content_privacypolicy_MAS = 'La version MAS n\'a aucune fonction réseau.';
-$content_privacypolicy_WEB = 'La version WEB utilise Sparkle pour le processus de mise à jour (que vous pouvez désactiver), afin que ce composant puisse se connecter à Internet. Il n\'est utilisé que pour vérifier pour une nouvelle version et la télécharger. Ce composant ne stocke ni ne partage aucune information, même pas les <a href="https://sparkle-project.org/documentation/system-profiling/">données anonymes du profile système</a> qui étaient activées dans certaines version de Keka antérieures à 1.0.0 mais jamais utilisées.';
+$content_privacypolicy_WEB = 'La version WEB utilise Sparkle pour le processus de mise à jour (que vous pouvez désactiver), afin que ce composant puisse se connecter à Internet. Il n\'est utilisé que pour vérifier si une nouvelle version est disponible et la télécharger. Ce composant ne stocke ni ne partage aucune information, même pas les <a href="https://sparkle-project.org/documentation/system-profiling/">données anonymes du profile système</a> qui étaient activées dans certaines version de Keka antérieures à 1.0.0 mais jamais utilisées.';
 
 // Main content of the page
 $content_context_menu = "Menu contextuel";
@@ -99,17 +99,17 @@ $content_context_menu = "Menu contextuel";
 // Changelog info
 $content_changelog_title = "Jettez un oeil à l\'évolution de Keka";
 $content_changelog_entry_title = "Modification de la version";
-$content_changelog_firstpublic = "Première version publique:";
+$content_changelog_firstpublic = "Première version publique :";
 
 // 404
 $content_404 = "Cette page ne peut être trouvée";
-$content_404_start = "Vous pouvez vous rendre à la <a href=\"https://www.keka.io\">page principale</a>";
+$content_404_start = "Vous pouvez vous rendre à la <a href=\"https://www.keka.io\">page d'accueil</a>";
 $content_404_more = "ou peut-être vous voulez ceci ?";
 
 // Maintenance
 $content_maintenance = "De retour bientôt";
 
 // Bottom info
-$content_bottom_copying = 'Tous droits réservés.';
+$content_bottom_copying = "Tous droits réservés.";
 
 ?>

--- a/Translations-iOS/Alternative-Strings-Files/fr.lproj/Localizable.strings
+++ b/Translations-iOS/Alternative-Strings-Files/fr.lproj/Localizable.strings
@@ -101,7 +101,7 @@
 "Allocated size" = "Taille allouée";
 
 /* Appearance settings title. */
-"Appearance" = "Apparance";
+"Appearance" = "Apparence";
 
 /* No comment provided by engineer. */
 "archive" = "archive";
@@ -690,4 +690,3 @@
 
 /* No comment provided by engineer. */
 "Where" = "Où";
-

--- a/Translations-macOS/Common/Translators.html
+++ b/Translations-macOS/Common/Translators.html
@@ -95,6 +95,7 @@
 		<span><a href="https://github.com/ejb4u">Ejb4u</a> and Jayflo276</span>
 		<span>Nicolas <a href="https://github.com/nicopasla">@nicopasla</a></span>
 		<span>Marc Croteau <a href="https://github.com/Marc66">@Marc66</a></span>
+        <span>Metin Bektas <a href="https://methbkts.com">@methbkts</a></span>
 	</span>
 
 	<!-- German -->

--- a/Translations-macOS/fr.lproj/preferences.strings
+++ b/Translations-macOS/fr.lproj/preferences.strings
@@ -156,7 +156,7 @@
 "AU8-I0-71W.title" = "Afficher les options de chiffrement avec le mot de passe par défaut";
 
 /* Class = "NSButtonCell"; title = "Create solid archives if possible"; ObjectID = "B4J-qZ-sDA"; */
-"B4J-qZ-sDA.title" = "Créer une archive solide si possible";
+"B4J-qZ-sDA.title" = "Créer une archive compacte si possible";
 
 /* Class = "NSMenuItem"; title = "Custom folder..."; ObjectID = "CWc-wN-FhI"; */
 "CWc-wN-FhI.title" = "Dossier personnalisé ...";


### PR DESCRIPTION
Updates French localization strings across macOS, iOS, and the website.

**Changes:**
- Adjusts a macOS preference string for “Create solid archives if possible”.
- Fixes an iOS French typo (“Apparance” → “Apparence”) and trims trailing whitespace.
- Updates French website copy (titles, donation text, privacy/changelog wording).
