### PR TITLE
Update zh-TW translation in macOS & iOS

### DIFF
--- a/Translations-iOS/zh-Hant.xcloc/Localized Contents/zh-Hant.xliff
+++ b/Translations-iOS/zh-Hant.xcloc/Localized Contents/zh-Hant.xliff
@@ -1270,7 +1270,7 @@ You can give access to the rest of the files or the parent folder.</source>
       </trans-unit>
       <trans-unit id="Try lowering the compression level, faster levels use less memory." xml:space="preserve">
         <source>Try lowering the compression level, faster levels use less memory.</source>
-        <target>請試著降低壓縮級別。較快的級別，使用的記憶體較少。</target>
+        <target>請試著降低壓縮級別，較快的級別，使用的記憶體較少。</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Type" xml:space="preserve">
@@ -1315,7 +1315,7 @@ You can give access to the rest of the files or the parent folder.</source>
       </trans-unit>
       <trans-unit id="Use AES-256 if Available" xml:space="preserve">
         <source>Use AES-256 if Available</source>
-        <target>盡可能使用AES-256</target>
+        <target>可用時使用AES-256</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Use Binaries if Possible" xml:space="preserve">
@@ -1325,7 +1325,7 @@ You can give access to the rest of the files or the parent folder.</source>
       </trans-unit>
       <trans-unit id="Use UTF-8 Encoding if Available" xml:space="preserve">
         <source>Use UTF-8 Encoding if Available</source>
-        <target>盡可能使用UTF-8編碼</target>
+        <target>可用時使用UTF-8編碼</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Use continuous background task" xml:space="preserve">

--- a/Translations-iOS/zh-Hant.xcloc/Localized Contents/zh-Hant.xliff
+++ b/Translations-iOS/zh-Hant.xcloc/Localized Contents/zh-Hant.xliff
@@ -1320,7 +1320,7 @@ You can give access to the rest of the files or the parent folder.</source>
       </trans-unit>
       <trans-unit id="Use Binaries if Possible" xml:space="preserve">
         <source>Use Binaries if Possible</source>
-        <target>盡可能使用二進位工具</target>
+        <target>盡可能使用二進位程式</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Use UTF-8 Encoding if Available" xml:space="preserve">

--- a/Translations-iOS/zh-Hant.xcloc/Localized Contents/zh-Hant.xliff
+++ b/Translations-iOS/zh-Hant.xcloc/Localized Contents/zh-Hant.xliff
@@ -1270,7 +1270,7 @@ You can give access to the rest of the files or the parent folder.</source>
       </trans-unit>
       <trans-unit id="Try lowering the compression level, faster levels use less memory." xml:space="preserve">
         <source>Try lowering the compression level, faster levels use less memory.</source>
-        <target>請試著降低壓縮級別，較快的級別，使用的記憶體較少。</target>
+        <target>請試著降低壓縮級別，較快的級別使用的記憶體較少。</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Type" xml:space="preserve">

--- a/Translations-iOS/zh-Hant.xcloc/Localized Contents/zh-Hant.xliff
+++ b/Translations-iOS/zh-Hant.xcloc/Localized Contents/zh-Hant.xliff
@@ -306,6 +306,7 @@
     <body>
       <trans-unit id="%@" xml:space="preserve">
         <source>%@</source>
+        <target>%@</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="%@ item" xml:space="preserve">
@@ -335,6 +336,7 @@
       </trans-unit>
       <trans-unit id="%@." xml:space="preserve">
         <source>%@.</source>
+        <target>%@。</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="%lld items" xml:space="preserve">
@@ -484,6 +486,7 @@
       </trans-unit>
       <trans-unit id="Appearance" xml:space="preserve">
         <source>Appearance</source>
+        <target>外觀</target>
         <note>Appearance settings title.</note>
       </trans-unit>
       <trans-unit id="Archive items separately" xml:space="preserve">
@@ -1242,6 +1245,7 @@ You can give access to the rest of the files or the parent folder.</source>
       </trans-unit>
       <trans-unit id="To be implemented" xml:space="preserve">
         <source>To be implemented</source>
+        <target>待實作</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="To extract" xml:space="preserve">
@@ -1266,6 +1270,7 @@ You can give access to the rest of the files or the parent folder.</source>
       </trans-unit>
       <trans-unit id="Try lowering the compression level, faster levels use less memory." xml:space="preserve">
         <source>Try lowering the compression level, faster levels use less memory.</source>
+        <target>請試著降低壓縮級別。較快的級別，使用的記憶體較少。</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Type" xml:space="preserve">
@@ -1310,20 +1315,22 @@ You can give access to the rest of the files or the parent folder.</source>
       </trans-unit>
       <trans-unit id="Use AES-256 if Available" xml:space="preserve">
         <source>Use AES-256 if Available</source>
-        <target>如果可以就使用AES-256</target>
+        <target>盡可能使用AES-256</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Use Binaries if Possible" xml:space="preserve">
         <source>Use Binaries if Possible</source>
+        <target>盡可能使用二進位工具</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Use UTF-8 Encoding if Available" xml:space="preserve">
         <source>Use UTF-8 Encoding if Available</source>
-        <target>如果可以就使用UTF-8編碼</target>
+        <target>盡可能使用UTF-8編碼</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Use continuous background task" xml:space="preserve">
         <source>Use continuous background task</source>
+        <target>使用持續執行的背景作業</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Use special coloring for known formats" xml:space="preserve">
@@ -1334,6 +1341,8 @@ You can give access to the rest of the files or the parent folder.</source>
       <trans-unit id="Using Keka through actions and extensions have memory limitations.&#10;Try this operation using Keka directly." xml:space="preserve">
         <source>Using Keka through actions and extensions have memory limitations.
 Try this operation using Keka directly.</source>
+        <target>透過動作和延伸功能使用Keka會遇到記憶體限制。
+請試著直接使用Keka執行此動作。</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="VERIFY_OPERATION" xml:space="preserve">

--- a/Translations-macOS/zh-Hant.lproj/Credits.strings
+++ b/Translations-macOS/zh-Hant.lproj/Credits.strings
@@ -7,7 +7,7 @@
 "_TESTERS_" = "非定期的程式測試員";
 "_DONATIONS_" = "贊助（依日期排序）";
 "_OPENSOURCE_" = "Keka 使用這些開放原始碼製作";
-"_FREEWARE_" = "Keka 使用的免費二進位檔案";
+"_FREEWARE_" = "Keka 使用的免費二進位工具";
 "_ONEMORETHING_" = "還有一件事";
 "_THANKS_" = "感謝您使用 Keka！";
 "_SOURCE_" = "由於部分法律因素，Keka 1.0 的原始碼無法公開。我們需要這方面的法律支援，若您能從法律方面協助本計畫，請至 info@keka.io 或 Keka Project 頁面聯絡我們。任何協助也無任歡迎。";

--- a/Translations-macOS/zh-Hant.lproj/Credits.strings
+++ b/Translations-macOS/zh-Hant.lproj/Credits.strings
@@ -7,7 +7,7 @@
 "_TESTERS_" = "非定期的程式測試員";
 "_DONATIONS_" = "贊助（依日期排序）";
 "_OPENSOURCE_" = "Keka 使用這些開放原始碼製作";
-"_FREEWARE_" = "Keka 使用的免費二進位工具";
+"_FREEWARE_" = "Keka 使用的免費二進位程式";
 "_ONEMORETHING_" = "還有一件事";
 "_THANKS_" = "感謝您使用 Keka！";
 "_SOURCE_" = "由於部分法律因素，Keka 1.0 的原始碼無法公開。我們需要這方面的法律支援，若您能從法律方面協助本計畫，請至 info@keka.io 或 Keka Project 頁面聯絡我們。任何協助也無任歡迎。";

--- a/Translations-macOS/zh-Hant.lproj/Localizable.strings
+++ b/Translations-macOS/zh-Hant.lproj/Localizable.strings
@@ -128,7 +128,7 @@
 "4.7 GB DVD" = "4.7 GB DVD";
 "Drop here to extract" = "拖曳到此以解壓縮";
 "Drop here to compress" = "拖曳到此以壓縮";
-"Binary \"%@\" is not accessible" = "無法存取「%@」二進位檔案";
+"Binary \"%@\" is not accessible" = "無法存取「%@」二進位工具";
 "The first part \"%@\" can't be found" = "找不到「%@」的第一部分";
 "Unable to extract a folder" = "無法解壓縮檔案夾";
 "unknown" = "未知";
@@ -152,8 +152,8 @@
 "Can't open the file, maybe it's not accessible" = "無法打開檔案，可能無法存取";
 "No files matching the mask" = "沒有符合遮罩的檔案";
 "There were some read errors" = "可能有讀取錯誤";
-"Dismissed trailing data, the extraction might be incomplete" = "Dismissed trailing data, the extraction might be incomplete";
-"Window size not supported, too much memory required" = "Window size not supported, too much memory required";
+"Dismissed trailing data, the extraction might be incomplete" = "已捨棄尾部資料，解壓縮的結果可能不完整";
+"Window size not supported, too much memory required" = "不支援滑動視窗大小，記憶體需求過大";
 "Give access" = "授予取用權限";
 "Just folder access" = "只有檔案夾取用權限";
 "Quit" = "結束";
@@ -252,7 +252,7 @@
 "Show password" = "顯示密碼";
 "Hide password" = "隱藏密碼";
 "Settings" = "偏好設定";
-"Format Selector" = "Format Selector";
+"Format Selector" = "格式選擇器";
 
 /* Keka preferences for macOS 12.0 and earlier */
 "Preferences…" = "偏好設定⋯";

--- a/Translations-macOS/zh-Hant.lproj/Localizable.strings
+++ b/Translations-macOS/zh-Hant.lproj/Localizable.strings
@@ -153,7 +153,7 @@
 "No files matching the mask" = "沒有符合遮罩的檔案";
 "There were some read errors" = "可能有讀取錯誤";
 "Dismissed trailing data, the extraction might be incomplete" = "已捨棄尾部資料，解壓縮的結果可能不完整";
-"Window size not supported, too much memory required" = "不支援滑動視窗大小，記憶體需求過大";
+"Window size not supported, too much memory required" = "不支援此視窗大小，記憶體需求過大";
 "Give access" = "授予取用權限";
 "Just folder access" = "只有檔案夾取用權限";
 "Quit" = "結束";

--- a/Translations-macOS/zh-Hant.lproj/Localizable.strings
+++ b/Translations-macOS/zh-Hant.lproj/Localizable.strings
@@ -128,7 +128,7 @@
 "4.7 GB DVD" = "4.7 GB DVD";
 "Drop here to extract" = "拖曳到此以解壓縮";
 "Drop here to compress" = "拖曳到此以壓縮";
-"Binary \"%@\" is not accessible" = "無法存取「%@」二進位工具";
+"Binary \"%@\" is not accessible" = "無法存取「%@」二進位程式";
 "The first part \"%@\" can't be found" = "找不到「%@」的第一部分";
 "Unable to extract a folder" = "無法解壓縮檔案夾";
 "unknown" = "未知";

--- a/Translations-macOS/zh-Hant.lproj/preferences.strings
+++ b/Translations-macOS/zh-Hant.lproj/preferences.strings
@@ -156,7 +156,7 @@
 "AU8-I0-71W.title" = "顯示使用預設密碼加密的項目";
 
 /* Class = "NSButtonCell"; title = "Create solid archives if possible"; ObjectID = "B4J-qZ-sDA"; */
-"B4J-qZ-sDA.title" = "Create solid archives if possible";
+"B4J-qZ-sDA.title" = "盡可能建立結實封存檔";
 
 /* Class = "NSMenuItem"; title = "Custom folder..."; ObjectID = "CWc-wN-FhI"; */
 "CWc-wN-FhI.title" = "自訂檔案夾⋯";


### PR DESCRIPTION
- **l10n(iOS/zh-Hant): update translation**
- **l10n(macOS/zh-Hant): update translation**

It's been a while since the zh-Hant translation of Keka was last updated - sorry!

---

For some terms:

- "Binaries" has been changed from the generic "二進位檔案" (binary files) to "二進位程式" (binary program)
- "Solid archive" (結實封存檔) is taken from the official WinRAR translation: https://rar.tw/product.html
- ~~Regarding the "Window" in "*Window* Size," after a discussion with Google AI Search, I believe it refers to the window in a sliding *window*. To avoid ambiguity, the full name is used.~~ Use "視窗" instead, no over-interpretation.